### PR TITLE
term our workers instead of graceful shutdown since they should be do…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ cache: bundler
 branches:
   only: master
 rvm:
-  - 2.1.5
   - 2.2.4
   - 2.3.1
+  - 2.4.2

--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -69,7 +69,7 @@ module UnicornWrangler
 
       report_status "Killing", reason, memory, requests, request_time
 
-      Process.kill(:QUIT, Process.pid)
+      Process.kill(:TERM, Process.pid)
     end
 
     # expensive, do not run on every request

--- a/spec/unicorn_wrangler_spec.rb
+++ b/spec/unicorn_wrangler_spec.rb
@@ -182,7 +182,7 @@ describe UnicornWrangler do
         expect(stats).to receive(:increment)
         expect(stats).to receive(:histogram).exactly(3)
 
-        expect(Process).to receive(:kill).with(:QUIT, Process.pid)
+        expect(Process).to receive(:kill).with(:TERM, Process.pid)
         wrangler.send(:kill, :foobar, 1, 2, 3)
       end
     end

--- a/unicorn_wrangler.gemspec
+++ b/unicorn_wrangler.gemspec
@@ -8,5 +8,5 @@ Gem::Specification.new name, UnicornWrangler::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib/ bin/ MIT-LICENSE`.split("\n")
   s.license = "MIT"
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 end


### PR DESCRIPTION
…ne at this point

unicorns http-server is the only one that traps `QUIT` ... so we should send the proper signal to the workers and not ask them for a stack-dump

@pschambacher 