### PR TITLE
Do not disable GC until we have to

### DIFF
--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -124,7 +124,6 @@ module UnicornWrangler
       @logger = logger
       @stats = stats
       @max_request_time = max_request_time
-      GC.disable
       @logger.info "Garbage collecting after #{@max_request_time}s of request processing time"
       @gc_ran_at = 0
     end

--- a/spec/unicorn_wrangler_spec.rb
+++ b/spec/unicorn_wrangler_spec.rb
@@ -157,12 +157,6 @@ describe UnicornWrangler do
   describe UnicornWrangler::OutOfBandGC do
     let(:wrangler) { described_class.new(logger, stats, 1000) }
 
-    it "disables GC" do
-      GC.enable
-      wrangler
-      expect(GC.enable).to eq(true) # was disabled
-    end
-
     it "runs GC after too much request time" do
       expect(GC).to receive(:start)
 


### PR DESCRIPTION
Currently we call `GC.disable` in two different phases: during initialization and during the rack middleware call, we can avoid doing that during initialization to prevent excessive memory use (~50% during my tests).

But memory usage shouldn't be the same with/without the gem... I wonder if `GC.disable` during the call is actually used, what would be the best way to test it? 