### PR TITLE
run GC and disable before forking the workers so they have a clean GC…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,3 @@ DEPENDENCIES
   single_cov
   unicorn
   unicorn_wrangler!
-
-BUNDLED WITH
-   1.15.3

--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -45,6 +45,14 @@ module UnicornWrangler
     def process_client(*)
       UnicornWrangler.perform_request { super }
     end
+
+    # run GC after we finished loading out app so forks inherit a clean GC environment
+    def build_app!
+      super
+    ensure
+      GC.start
+      GC.disable
+    end
   end
 
   class Killer

--- a/spec/unicorn_wrangler_spec.rb
+++ b/spec/unicorn_wrangler_spec.rb
@@ -6,6 +6,9 @@ module Unicorn
   class HttpServer
     def process_client(_client)
     end
+
+    def build_app!
+    end
   end
 end
 
@@ -188,12 +191,25 @@ describe UnicornWrangler do
       def process_client(client)
         123
       end
+
+      def build_app!
+        123
+      end
     end
 
     describe "#process_client" do
       it "calls wrangler" do
         expect(UnicornWrangler).to receive(:perform_request).and_return(123)
         expect(Foobar.new.process_client(:foo)).to eq(123)
+      end
+    end
+
+    describe "#build_app!" do
+      it "disables GC" do
+        GC.enable
+        expect(GC).to receive(:start)
+        expect(Foobar.new.build_app!).to eq 123
+        expect(GC.enable).to eq true # was off ?
       end
     end
   end


### PR DESCRIPTION
… environment

@pschambacher @mikhailov 

```Ruby
after_fork do |a, b|
  puts "GC RUN #{Benchmark.realtime { GC.enable; GC.start }}"
end
```

before: "GC RUN 0.4367703919997439"
after: "GC RUN 0.14816381700075"

memory after booting:
before:  257MiB
after:  257MiB