### PR TITLE
add support for finish requests before stopping

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,8 @@
-Unicorn: out of band GC / restart on max memory bloat / restart after X requests
+Unicorn helpers for: 
+ - out of band GC 
+ - restart on max memory bloat
+ - restart after X requests
+ - not killing active requests when stopping (map TERM into QUIT see [heroku docs](https://devcenter.heroku.com/articles/rails-unicorn#signal-handling))
 
 Install
 =======
@@ -22,6 +26,7 @@ UnicornWrangler.setup(
     check_every: 250 # requests
   },
   gc_after_request_time: 10, # seconds
+  map_term_to_quit: true, # finish requests before stopping
   stats: StatsD.new,
   logger: set.fetch(:logger)
 )

--- a/spec/config.ru
+++ b/spec/config.ru
@@ -1,4 +1,5 @@
 run ->(env) do
   sleep 0.11 if env['PATH_INFO'] == '/slow'
-  [200, {}, ["Foo"]]
+  sleep 0.5 if env['PATH_INFO'] == '/vslow'
+  [200, {}, ["Foo #{Process.pid}"]]
 end

--- a/spec/server.rb
+++ b/spec/server.rb
@@ -2,7 +2,7 @@ require 'datadog/statsd'
 require 'unicorn_wrangler'
 
 pid 'unicorn.pid'
-listen 3000
+listen 3234
 log = 'unicorn.log'
 stdout_path log # make puts debugging visible
 log = Logger.new('unicorn.log')
@@ -15,8 +15,13 @@ UnicornWrangler.setup(
   gc_after_request_time: 0.1,
   kill_after_requests: killer == 'requests' && 5,
   kill_on_too_much_memory: killer == 'memory' && {max: 0, check_every: 3},
+  map_term_to_quit: ENV["MAP_TERM_TO_QUIT"],
   stats: stats,
   logger: log
 )
 
 UnicornWrangler.handlers << -> (a,b) { log.info "Custom handler" }
+
+if ENV["BEFORE_HOOK"]
+  before_fork { |a, b| puts "GOT BEFORE_HOOK" }
+end

--- a/spec/unicorn_wrangler_spec.rb
+++ b/spec/unicorn_wrangler_spec.rb
@@ -18,10 +18,27 @@ class Stats
   end
 end
 
+module UnicornWrangler::Signal
+  class << self
+    def trap(_sig, &block)
+      (@trapped ||= []) << block
+    end
+
+    def trapped
+      @trapped
+    end
+  end
+end
+
 describe UnicornWrangler do
   let(:log) { StringIO.new }
   let(:logger) { Logger.new(log) }
   let(:stats) { Stats.new }
+
+  before do
+    UnicornWrangler.instance_variable_set(:@hooks, nil)
+    UnicornWrangler.instance_variable_set(:@handlers, nil)
+  end
 
   it "has a VERSION" do
     expect(UnicornWrangler::VERSION).to match /^[\.\da-z]+$/
@@ -30,19 +47,21 @@ describe UnicornWrangler do
   describe "integration" do
     def server
       log = 'spec/unicorn.log'
-      begin
-        `cd spec && unicorn -c server.rb -D`
-        yield
-        sleep 0.1 # sleep for log to flush
-        File.read(log)
-      ensure
-        Process.kill(:TERM, Integer(File.read('spec/unicorn.pid')))
-        File.unlink(log)
-      end
+      `cd spec && unicorn -c server.rb -D --no-default-middleware`
+      yield
+      sleep 0.1 # sleep for log to flush
+      File.read(log)
+    rescue
+      puts "LOGS: #{File.read(log)}" if File.exist?(log)
+      raise
+    ensure
+      Process.kill(:TERM, master_pid)
+      File.unlink(log)
     end
 
+    # don't use open.read, it retries
     def get(path='/')
-      open("http://localhost:3000#{path}").read
+      `curl -sf http://localhost:3234#{path}`
     end
 
     def with_env(env)
@@ -52,6 +71,16 @@ describe UnicornWrangler do
     ensure
       old.each { |k, v| ENV[k.to_s] = v }
     end
+
+    def child_pids(pid)
+      pipe = IO.popen("ps -ef | grep #{pid}")
+      pipe.readlines.map do |line|
+        parts = line.strip.split(/\s+/)
+        parts[1].to_i if parts[2] == pid.to_s and parts[1] != pipe.pid.to_s
+      end.compact
+    end
+
+    let(:master_pid) { Integer(File.read('spec/unicorn.pid')) }
 
     it "calls custom handler" do
       log = server { expect(get).to include("Foo") }
@@ -75,6 +104,44 @@ describe UnicornWrangler do
     it "runs GC reaching max request time" do
       log = server { get '/slow' }
       expect(log).to include "Garbage collecting: took"
+    end
+
+    it "runs custom before hook" do
+      with_env BEFORE_HOOK: 'true' do
+        log = server { get }
+        expect(log).to include "GOT BEFORE_HOOK"
+      end
+    end
+
+    it "runs custom hook even when we hijack the hook" do
+      with_env BEFORE_HOOK: 'true', MAP_TERM_TO_QUIT: 'true' do
+        log = server { get }
+        expect(log).to include "GOT BEFORE_HOOK"
+      end
+    end
+
+    it "finishes requests when master receives TERM" do
+      with_env MAP_TERM_TO_QUIT: 'true' do
+        client = nil
+        # server stays open for 0.1s and then sends itself TERM, but client request takes 0.5s
+        server = Thread.new { server { client = Thread.new { get '/vslow' }} }
+        log = server.value
+        client.join
+        expect(log).to include "worker=0 ready"
+      end
+    end
+
+    it "finishes requests when worker receives TERM" do
+      with_env MAP_TERM_TO_QUIT: 'true' do
+        log = server do
+          client = Thread.new { get('/vslow') }
+          sleep 0.2 # let worker boot ... request will take 0.5s so it still runs after
+          worker = child_pids(master_pid).first || raise("No child found")
+          Process.kill(:TERM, worker) # send term to worker which it should ignore
+          expect(client.value).to eq "Foo #{worker}"
+        end
+        expect(log).to include "worker=0 ready"
+      end
     end
   end
 
@@ -104,6 +171,17 @@ describe UnicornWrangler do
       )
       expect(log.string.split("\n").size).to eq 0
     end
+
+    it "can add additional before hook" do
+      UnicornWrangler.setup(logger: logger, map_term_to_quit: true)
+
+      expect(Process).to receive(:kill)
+      expect(logger).to receive(:info).exactly(2)
+      UnicornWrangler.perform_hook :before_fork
+      UnicornWrangler.perform_hook :after_fork
+      UnicornWrangler::Signal.trapped.each { |h| h.call 1, 2 }
+      sleep 0.1 # let logger thread finish
+    end
   end
 
   describe ".perform_request" do
@@ -113,6 +191,20 @@ describe UnicornWrangler do
       UnicornWrangler.handlers.replace [-> (*args) { called << args }]
       expect(UnicornWrangler.perform_request { 123 }).to eq(123)
       expect(called.first.first).to eq(1)
+    end
+  end
+
+  describe ".perform_before_fork" do
+    it "does nothing when nothing was configured" do
+      UnicornWrangler.instance_variable_set(:@hooks, {})
+      UnicornWrangler.perform_hook :before_fork
+    end
+
+    it "performs" do
+      called = []
+      UnicornWrangler.instance_variable_set(:@hooks, before_fork: -> { called << 1 })
+      UnicornWrangler.perform_hook :before_fork
+      expect(called).to eq([1])
     end
   end
 
@@ -211,6 +303,14 @@ describe UnicornWrangler do
       def build_app!
         123
       end
+
+      def before_fork=(x)
+        @before_fork = x
+      end
+
+      def before_fork
+        @before_fork.call(1, 2)
+      end
     end
 
     describe "#process_client" do
@@ -226,6 +326,17 @@ describe UnicornWrangler do
         expect(GC).to receive(:start)
         expect(Foobar.new.build_app!).to eq 123
         expect(GC.enable).to eq true # was off ?
+      end
+    end
+
+    describe "hooks" do
+      it "calls original and ours" do
+        called = []
+        UnicornWrangler.instance_variable_set(:@hooks, before_fork: ->(*){ called << 1 })
+        server = Foobar.new
+        server.before_fork = ->(*) { called << 2 }
+        server.before_fork
+        expect(called).to eq [1, 2]
       end
     end
   end


### PR DESCRIPTION
this also has the advantage of keeping the original unicorn hooks working,
which log when the workers are spawned/killed

@libo @jacobat @bquorning @dasch @ilkkao