### PR TITLE
introduce proc based rss reading to avoid forking and making a system call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-17
 
 DEPENDENCIES
   bump
@@ -45,4 +46,4 @@ DEPENDENCIES
   unicorn_wrangler!
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -3,6 +3,7 @@
 # - runs GC out of band (does not block requests)
 
 require 'benchmark'
+require 'unicorn_wrangler/rss_reader'
 
 module UnicornWrangler
   STATS_NAMESPACE = 'unicorn'
@@ -130,9 +131,9 @@ module UnicornWrangler
       UnicornWrangler.kill_worker
     end
 
-    # expensive, do not run on every request
+    # RSS memory in MB
     def used_memory
-      `ps -o rss= -p #{Process.pid}`.to_i / 1024
+      RssReader.rss / 1024**2
     end
 
     def report_status(status, reason, memory, requests, request_time)

--- a/lib/unicorn_wrangler/rss_reader.rb
+++ b/lib/unicorn_wrangler/rss_reader.rb
@@ -1,0 +1,40 @@
+module UnicornWrangler
+  class RssReader
+    LINUX = RbConfig::CONFIG['host_os'].start_with?('linux')
+    PS_CMD = "ps -o rss= -p %d".freeze
+    UNITS  = {
+      b:  1024**0,
+      kb: 1024**1,
+      mb: 1024**2,
+      gb: 1024**3,
+      tb: 1024**4,
+    }.freeze
+
+    class << self
+      # Returns RSS in bytes; should work on Linux and Mac OS X
+      def rss(pid=Process.pid)
+        LINUX ? rss_linux(pid) : rss_posix(pid)
+      end
+
+      # Fork/exec ps and parse result.
+      # Should work on any system with POSIX ps.
+      # ~4ms
+      def rss_posix(pid=Process.pid)
+        `#{PS_CMD % [pid]}`.to_i * 1024
+      end
+
+      # Read from /proc/$pid/status.  Linux only.
+      # ~100x faster and doesn't incur significant memory cost.
+      def rss_linux(pid=Process.pid)
+        File.open("/proc/#{pid}/status") do |file|
+          file.each_line do |line|
+            if line[/^VmRSS/]
+              _,c,u = line.split
+              return (c.to_i * UNITS[u.downcase.to_sym]).to_i
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unicorn_wrangler/rss_reader_spec.rb
+++ b/spec/unicorn_wrangler/rss_reader_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper'
+require 'unicorn_wrangler/rss_reader'
+
+# Travis is a linux system so we won't test the rss_posix call there,
+# but make no assumptions about running locally.
+SingleCov.covered! uncovered: ENV['TRAVIS'] ? 1 : 6
+
+describe UnicornWrangler::RssReader do
+  describe '.rss_posix' do
+    it 'returns an integer of bytes' do
+      expect(UnicornWrangler::RssReader.rss_posix).to be < 200 * 1024**2
+      expect(UnicornWrangler::RssReader.rss_posix).to be > 5 * 1024**2
+    end
+  end
+
+  describe '.rss_linux' do
+    if UnicornWrangler::RssReader::LINUX || ENV['TRAVIS']
+      it 'returns an integer of bytes' do
+        expect(UnicornWrangler::RssReader.rss_posix).to be < 200 * 1024**2
+        expect(UnicornWrangler::RssReader.rss_posix).to be > 5 * 1024**2
+      end
+
+      it 'has approximate parity with rss_posix' do
+        # GC shouldn't grow our heap or malloc more than this between calls
+        expect(UnicornWrangler::RssReader.rss_linux).to be_within(32 * 1024**2).of(UnicornWrangler::RssReader.rss_posix)
+      end
+    else
+      it 'can not be tested' do
+        skip 'platform is non-Linux, can not test /proc RSS reading.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reading from `/proc` is significantly faster and cheaper on a Linux system than forking to make a system call from Ruby. This introduces a `RssReader` class to use `/proc` when possible, but still falls back to shelling out to `ps` when `/proc` isn't available. 

The credit for this all goes to @gabetax

/cc @grosser 