### PR TITLE
Set appropriate log levels

### DIFF
--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -125,7 +125,7 @@ module UnicornWrangler
         @stats.histogram("#{STATS_NAMESPACE}.kill.total_request_time", request_time)
       end
 
-      report_status "Killing", reason, memory, requests, request_time
+      report_status "Killing", reason, memory, requests, request_time, :warn
 
       UnicornWrangler.kill_worker
     end
@@ -135,8 +135,8 @@ module UnicornWrangler
       `ps -o rss= -p #{Process.pid}`.to_i / 1024
     end
 
-    def report_status(status, reason, memory, requests, request_time)
-      @logger.info "#{status} unicorn worker ##{Process.pid} for #{reason}. Requests: #{requests}, Time: #{request_time}, Memory: #{memory}MB"
+    def report_status(status, reason, memory, requests, request_time, log_level = :debug)
+      @logger.send log_level, "#{status} unicorn worker ##{Process.pid} for #{reason}. Requests: #{requests}, Time: #{request_time}, Memory: #{memory}MB"
     end
   end
 
@@ -202,7 +202,7 @@ module UnicornWrangler
         @stats.increment("#{STATS_NAMESPACE}.oobgc.runs")
         @stats.timing("#{STATS_NAMESPACE}.oobgc.time", time)
       end
-      @logger.info "Garbage collecting: took #{time}ms"
+      @logger.debug "Garbage collecting: took #{time}ms"
       true
     end
   end


### PR DESCRIPTION
cc @grosser 
fyi @damiann @codealchemy @pschambacher 

Some logging happens too frequent, like GC runs and current memory usage. The same information in those logs messages is sent as metrics, so switching them to debug level allows applications to control if debug level logging should be sent to whatever logging tool they use.

Information about initialization is kept as info, as it is useful information and only happens once, when application is booting.

Kill messages are change to warn level, so applications can give them higher visibility.

Some logging example:
```
D, [2020-09-22T10:18:20.050731 #87078] DEBUG -- : Keeping unicorn worker #87078 for memory. Requests: 250, Time: 100, Memory: 0MB
I, [2020-09-22T10:18:20.057665 #87078]  INFO -- : Garbage collecting after 1000s of request processing time
I, [2020-09-22T10:18:20.057850 #87078]  INFO -- : Garbage collecting after 1000s of request processing time
D, [2020-09-22T10:18:20.074658 #87078] DEBUG -- : Garbage collecting: took 17ms
W, [2020-09-22T10:18:20.075990 #87078]  WARN -- : Killing unicorn worker #87078 for foobar. Requests: 2, Time: 3, Memory: 1MB
W, [2020-09-22T10:18:20.077144 #87078]  WARN -- : Killing unicorn worker #87078 for foobar. Requests: 2, Time: 3, Memory: 1MB
```