### PR TITLE
add readers for request count and time

### DIFF
--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -8,7 +8,7 @@ module UnicornWrangler
   STATS_NAMESPACE = 'unicorn'
 
   class << self
-    attr_reader :handlers
+    attr_reader :handlers, :requests, :request_time
     attr_accessor :sending_myself_term
 
     # called from unicorn config (usually config/unicorn.rb)


### PR DESCRIPTION
This adds two more readers for the request stats information so the running application can record these stats if desired.