### PR TITLE
introduce an rss reader and /proc/status reading for performance

### DIFF
--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -3,6 +3,7 @@
 # - runs GC out of band (does not block requests)
 
 require 'benchmark'
+require 'unicorn_wrangler/rss_reader'
 
 module UnicornWrangler
   STATS_NAMESPACE = 'unicorn'
@@ -109,6 +110,7 @@ module UnicornWrangler
     def initialize(logger, stats)
       @logger = logger
       @stats = stats
+      @rss_reader = RssReader.new(logger: logger)
     end
 
     private
@@ -130,9 +132,9 @@ module UnicornWrangler
       UnicornWrangler.kill_worker
     end
 
-    # expensive, do not run on every request
+    # RSS memory in MB
     def used_memory
-      `ps -o rss= -p #{Process.pid}`.to_i / 1024
+      @rss_reader.rss_mb
     end
 
     def report_status(status, reason, memory, requests, request_time, log_level = :debug)

--- a/lib/unicorn_wrangler.rb
+++ b/lib/unicorn_wrangler.rb
@@ -132,9 +132,9 @@ module UnicornWrangler
       UnicornWrangler.kill_worker
     end
 
-    # RSS memory in MB
+    # RSS memory in MB. Can be expensive, do not run on every request
     def used_memory
-      @rss_reader.rss_mb
+      @rss_reader.rss
     end
 
     def report_status(status, reason, memory, requests, request_time, log_level = :debug)

--- a/lib/unicorn_wrangler/rss_reader.rb
+++ b/lib/unicorn_wrangler/rss_reader.rb
@@ -28,13 +28,14 @@ module UnicornWrangler
     # Fork/exec ps and parse result.
     # Should work on any system with POSIX ps.
     # ~4ms
-    def rss_posix(pid = Process.pid)
+    # returns kb but we want b
+    def rss_posix(pid)
       `#{PS_CMD % [pid]}`.to_i * 1024
     end
 
     # Read from /proc/$pid/status.  Linux only.
     # ~100x faster and doesn't incur significant memory cost.
-    def rss_linux(pid = Process.pid)
+    def rss_linux(pid)
       if line = File.read("/proc/#{pid}/status").lines.find { |l| l.start_with?('VmRSS') }
         _,c,u = line.chomp.split
 

--- a/lib/unicorn_wrangler/rss_reader.rb
+++ b/lib/unicorn_wrangler/rss_reader.rb
@@ -1,3 +1,5 @@
+# Read RSS based on the OS we are in. When in linux, we can read the proc status file and parse out
+# the RSS which is much faster than forking+execing ps.
 module UnicornWrangler
   class RssReader
     LINUX = RbConfig::CONFIG['host_os'].start_with?('linux')

--- a/lib/unicorn_wrangler/rss_reader.rb
+++ b/lib/unicorn_wrangler/rss_reader.rb
@@ -1,0 +1,51 @@
+module UnicornWrangler
+  class RssReader
+    LINUX = RbConfig::CONFIG['host_os'].start_with?('linux')
+    PS_CMD = 'ps -o rss= -p %d'.freeze
+    UNITS  = {
+      b:  1024**0,
+      kb: 1024**1,
+      mb: 1024**2,
+      gb: 1024**3,
+      tb: 1024**4,
+    }.freeze
+
+    def initialize(logger:)
+      @logger = logger
+    end
+
+    # Returns RSS in bytes; should work on Linux and Mac OS X
+    def rss(pid: Process.pid)
+      LINUX ? rss_linux(pid) : rss_posix(pid)
+    end
+
+    def rss_mb(pid: Process.pid)
+      rss(pid: pid) / UNITS[:mb]
+    end
+
+    private
+
+    # Fork/exec ps and parse result.
+    # Should work on any system with POSIX ps.
+    # ~4ms
+    def rss_posix(pid = Process.pid)
+      `#{PS_CMD % [pid]}`.to_i * 1024
+    end
+
+    # Read from /proc/$pid/status.  Linux only.
+    # ~100x faster and doesn't incur significant memory cost.
+    def rss_linux(pid = Process.pid)
+      if line = File.read("/proc/#{pid}/status").lines.find { |l| l.start_with?('VmRSS') }
+        _,c,u = line.chomp.split
+
+        (c.to_i * UNITS[u.downcase.to_sym]).to_i
+      else
+        @logger.warn 'Failed to parse proc status file, falling back to exec+ps' if @logger
+        rss_posix(pid)
+      end
+    rescue
+      @logger.warn 'Failed to read RSS from /proc, falling back to exec+ps' if @logger
+      rss_posix(pid)
+    end
+  end
+end

--- a/spec/unicorn_wrangler/rss_reader_spec.rb
+++ b/spec/unicorn_wrangler/rss_reader_spec.rb
@@ -1,0 +1,87 @@
+require_relative '../spec_helper'
+require 'unicorn_wrangler/rss_reader'
+
+SingleCov.covered!
+
+describe UnicornWrangler::RssReader do
+  shared_examples 'rss reader' do
+    it 'returns an integer of bytes' do
+      expect(reader.rss).to be < 200 * 1024**2
+      expect(reader.rss).to be > 5 * 1024**2
+    end
+  end
+
+  let(:log_io) { StringIO.new }
+  let(:logger) { Logger.new(log_io) }
+  let(:reader) { UnicornWrangler::RssReader.new(logger: logger) }
+
+  describe '.rss' do
+    let(:rss) { reader.rss }
+
+    context 'on a linux system' do
+      before do
+        stub_const('UnicornWrangler::RssReader::LINUX', true)
+      end
+
+      it_behaves_like 'rss reader'
+
+      context 'when reading from proc status file' do
+        before do
+          allow(File).to receive(:read).and_return("VmRSS:	    5748 kB\n")
+        end
+
+        it_behaves_like 'rss reader'
+
+        context 'and the file contains unexpected data' do
+          before do
+            allow(File).to receive(:read).and_return('nonsense')
+          end
+
+          it_behaves_like 'rss reader'
+
+          context 'and a logger is not given' do
+            let(:logger) { nil }
+
+            it 'does not raise errors' do
+              expect { reader.rss }.not_to raise_error
+            end
+          end
+        end
+
+        context 'and an error occurs' do
+          before do
+            allow(File).to receive(:read).and_raise('error')
+          end
+
+          it_behaves_like 'rss reader'
+
+          context 'and a logger is not given' do
+            let(:logger) { nil }
+
+            it 'does not raise errors' do
+              expect { reader.rss }.not_to raise_error
+            end
+          end
+        end
+      end
+    end
+
+    context 'on a posix system' do
+      before do
+        stub_const('UnicornWrangler::RssReader::LINUX', false)
+      end
+
+      it_behaves_like 'rss reader'
+    end
+  end
+
+  describe '.rss_mb' do
+    before do
+      allow(reader).to receive(:rss).and_return(4194304)
+    end
+
+    it 'equals rss converted to MB' do
+      expect(reader.rss_mb).to eq 4
+    end
+  end
+end

--- a/spec/unicorn_wrangler/rss_reader_spec.rb
+++ b/spec/unicorn_wrangler/rss_reader_spec.rb
@@ -6,8 +6,8 @@ SingleCov.covered!
 describe UnicornWrangler::RssReader do
   shared_examples 'rss reader' do
     it 'returns an integer of bytes' do
-      expect(reader.rss).to be < 200 * 1024**2
-      expect(reader.rss).to be > 5 * 1024**2
+      expect(reader.rss).to be < 200
+      expect(reader.rss).to be > 1
     end
   end
 
@@ -31,22 +31,6 @@ describe UnicornWrangler::RssReader do
         end
 
         it_behaves_like 'rss reader'
-
-        context 'and the file contains unexpected data' do
-          before do
-            allow(File).to receive(:read).and_return('nonsense')
-          end
-
-          it_behaves_like 'rss reader'
-
-          context 'and a logger is not given' do
-            let(:logger) { nil }
-
-            it 'does not raise errors' do
-              expect { reader.rss }.not_to raise_error
-            end
-          end
-        end
 
         context 'and an error occurs' do
           before do
@@ -72,16 +56,6 @@ describe UnicornWrangler::RssReader do
       end
 
       it_behaves_like 'rss reader'
-    end
-  end
-
-  describe '.rss_mb' do
-    before do
-      allow(reader).to receive(:rss).and_return(4194304)
-    end
-
-    it 'equals rss converted to MB' do
-      expect(reader.rss_mb).to eq 4
     end
   end
 end


### PR DESCRIPTION
This is a reintroduction and refactor of #9 with better test coverage and error handling.

Reading from /proc is significantly faster and cheaper on a Linux system than forking to make a system call from Ruby. This introduces a RssReader class to use /proc when possible, but still falls back to shelling out to ps when /proc isn't available.

/cc @gabetax